### PR TITLE
Switch to state management using reference types

### DIFF
--- a/Sources/Model/Data Flow/Model.swift
+++ b/Sources/Model/Data Flow/Model.swift
@@ -61,7 +61,7 @@ public protocol Model {
 public struct ModelData {
 
     /// The state value's identifier.
-    var id: String
+    var storage: StateContent.Storage
     /// Whether to force update the views when this value changes.
     var force: Bool
 
@@ -78,8 +78,8 @@ extension Model {
             guard let data = model else {
                 return
             }
-            StateManager.setState(id: data.id, value: newValue)
-            StateManager.updateState(id: data.id)
+            data.storage.value = newValue
+            data.storage.update = true
             StateManager.updateViews(force: data.force)
         }
     }
@@ -98,8 +98,8 @@ extension Model {
         }
         var model = getModel()
         setModel(&model)
-        StateManager.setState(id: data.id, value: model)
-        StateManager.updateState(id: data.id)
+        data.storage.value = model
+        data.storage.update = true
         StateManager.updateViews(force: data.force)
     }
 
@@ -112,7 +112,7 @@ extension Model {
         guard let data = model else {
             return self
         }
-        return StateManager.getState(id: data.id) as? Self ?? self
+        return data.storage.value as? Self ?? self
     }
 
 }

--- a/Sources/Model/Data Flow/StateContent.swift
+++ b/Sources/Model/Data Flow/StateContent.swift
@@ -9,30 +9,34 @@
 class StateContent {
 
     /// The storage.
-    var storage: Storage {
+    var storage: Storage?
+
+    /// The value.
+    var value: Any? {
         get {
-            if let internalStorage {
-                return internalStorage
-            }
-            let value = getInitialValue()
-            let storage = Storage(value: value)
-            internalStorage = storage
-            return storage
+            storage?.value
         }
         set {
-            internalStorage = newValue
+            if let storage {
+                storage.value = newValue as Any
+            } else {
+                storage = .init(value: newValue as Any)
+            }
         }
     }
-    /// The internal storage.
-    var internalStorage: Storage?
-    /// The initial value.
-    private var getInitialValue: () -> Any
+
+    /// Whether to update the views.
+    var update: Bool {
+        get {
+            storage?.update ?? false
+        }
+        set {
+            storage?.update = newValue
+        }
+    }
 
     /// Initialize the content without already initializing the storage or initializing the value.
-    /// - Parameter initialValue: The initial value.
-    init(getInitialValue: @escaping () -> Any) {
-        self.getInitialValue = getInitialValue
-    }
+    init() { }
 
     /// A class storing the value.
     class Storage {

--- a/Sources/Model/Data Flow/StateManager.swift
+++ b/Sources/Model/Data Flow/StateManager.swift
@@ -12,41 +12,10 @@ public enum StateManager {
 
     /// Whether to block updates in general.
     public static var blockUpdates = false
-    /// Whether to save state.
-    public static var saveState = true
     /// The application identifier.
     static var appID: String?
     /// The functions handling view updates.
     static var updateHandlers: [(Bool) -> Void] = []
-    /// The state.
-    static var state: [State] = []
-
-    /// Information about a piece of state.
-    struct State {
-
-        /// The state's identifier.
-        var id: String
-        /// Old identifiers of the state which need to be saved.
-        var oldIDs: [String] = []
-        /// The state value.
-        var value: Any?
-        /// Whether to update in the next iteration.
-        var update = false
-
-        /// Whether the state's identifiers contain a certain identifier.
-        /// - Parameter id: The identifier.
-        /// - Returns: Whether the id is contained.
-        func contains(id: String) -> Bool {
-            id == self.id || oldIDs.contains(id)
-        }
-
-        /// Change the identifier to a new one.
-        /// - Parameter newID: The new identifier.
-        mutating func changeID(new newID: String) {
-            id = newID
-        }
-
-    }
 
     /// Update all of the views.
     /// - Parameter force: Whether to force all views to update.
@@ -57,9 +26,6 @@ public enum StateManager {
             for handler in updateHandlers {
                 handler(force)
             }
-            for state in state where state.update {
-                updatedState(id: state.id)
-            }
         }
     }
 
@@ -67,66 +33,6 @@ public enum StateManager {
     /// - Parameter handler: The handler. The parameter defines whether the whole UI should be force updated.
     static func addUpdateHandler(handler: @escaping (Bool) -> Void) {
         updateHandlers.append(handler)
-    }
-
-    /// Set the state value for a certain ID.
-    /// - Parameters:
-    ///   - id: The identifier.
-    ///   - value: The new value.
-    static func setState(id: String, value: Any?) {
-        if saveState {
-            guard let index = state.firstIndex(where: { $0.contains(id: id) }) else {
-                state.append(.init(id: id, value: value))
-                return
-            }
-            state[safe: index]?.value = value
-        }
-    }
-
-    /// Get the state value for a certain ID.
-    /// - Parameter id: The identifier.
-    /// - Returns: The value.
-    static func getState(id: String) -> Any? {
-        state[safe: state.firstIndex { $0.contains(id: id) }]?.value
-    }
-
-    /// Mark the state of a certain id as updated.
-    /// - Parameter id: The identifier.
-    static func updateState(id: String) {
-        if saveState {
-            state[safe: state.firstIndex { $0.contains(id: id) }]?.update = true
-        }
-    }
-
-    /// Mark the state of a certain id as not updated.
-    /// - Parameter id: The identifier.
-    static func updatedState(id: String) {
-        if saveState {
-            state[safe: state.firstIndex { $0.contains(id: id) }]?.update = false
-        }
-    }
-
-    /// Get whether to update the state of a certain id.
-    /// - Parameter id: The identifier.
-    /// - Returns: Whether to update the state.
-    static func getUpdateState(id: String) -> Bool {
-        state[safe: state.firstIndex { $0.contains(id: id) }]?.update ?? false
-    }
-
-    /// Change the identifier for a certain state value.
-    /// - Parameters:
-    ///   - oldID: The old identifier.
-    ///   - newID: The new identifier.
-    static func changeID(old oldID: String, new newID: String) {
-        if saveState {
-            state[safe: state.firstIndex { $0.contains(id: oldID) }]?.changeID(new: newID)
-        }
-    }
-
-    /// Save a state's identifier until the program ends.
-    /// - Parameter id: The identifier.
-    static func addConstantID(_ id: String) {
-        state[safe: state.firstIndex { $0.id == id }]?.oldIDs.append(id)
     }
 
 }

--- a/Sources/Model/Data Flow/StateProtocol.swift
+++ b/Sources/Model/Data Flow/StateProtocol.swift
@@ -10,7 +10,7 @@ import Foundation
 /// An interface for accessing `State` without specifying the generic type.
 protocol StateProtocol {
 
-    /// The identifier for the state property's value.
-    var id: String { get set }
+    /// The state content.
+    var content: StateContent { get }
 
 }

--- a/Sources/Model/User Interface/App/App.swift
+++ b/Sources/Model/User Interface/App/App.swift
@@ -62,16 +62,7 @@ extension App {
         appInstance.app = Storage(id: appInstance.id)
         appInstance.app.storage.app = { appInstance }
         StateManager.addUpdateHandler { force in
-            var updateProperties = force
-            for property in appInstance.getState() {
-                if let oldID = appInstance.app.storage.stateStorage[property.key]?.id {
-                    StateManager.changeID(old: oldID, new: property.value.id)
-                    appInstance.app.storage.stateStorage[property.key]?.id = property.value.id
-                }
-                if StateManager.getUpdateState(id: property.value.id) {
-                    updateProperties = true
-                }
-            }
+            let updateProperties = force || appInstance.getState().contains { $0.value.content.update }
             var removeIndices: [Int] = []
             for (index, element) in appInstance.app.storage.sceneStorage.enumerated() {
                 if element.destroy {

--- a/Sources/View/StateWrapper.swift
+++ b/Sources/View/StateWrapper.swift
@@ -43,12 +43,12 @@ struct StateWrapper: ConvenienceWidget {
     ) where Data: ViewRenderData {
         var updateProperties = updateProperties
         for property in state {
-            if let oldID = storage.state[property.key]?.id {
-                StateManager.changeID(old: oldID, new: property.value.id)
-                storage.state[property.key]?.id = property.value.id
+            if let storage = storage.state[property.key]?.content.storage {
+                property.value.content.storage = storage
             }
-            if StateManager.getUpdateState(id: property.value.id) {
+            if property.value.content.update {
                 updateProperties = true
+                property.value.content.update = false
             }
         }
         guard let storage = storage.content[.mainContent]?.first else {


### PR DESCRIPTION
## Steps
- [x] Build the project on your machine. If it does not compile, fix the errors.
- [x] Describe the purpose and approach of your pull request below.
- [x] Submit the pull request. Thank you very much for your contribution!

## Purpose
The identifier system using value types only may have a slightly better performance (the difference really seems to be insignificant though), but results in strange behavior in certain situations:

```swift
struct Test: View {

    @State private var property1 = false
    @State private var property2 = false

    var view: Body {
        Button("Toggle") {
            property1.toggle()
            property2.toggle() // Nothing happens as the IDs already changed
        }
    }

}
```

With the reference type approach, the reference to the value will work as long as it exists and not break with the next update.

## Approach
Remove `StateManager`'s function of storing state and store state in a decentralized way instead.